### PR TITLE
[add] slick codegen plugin

### DIFF
--- a/app/sc/ript/cgmlms/infra/database/Tables.scala
+++ b/app/sc/ript/cgmlms/infra/database/Tables.scala
@@ -1,0 +1,95 @@
+package sc.ript.cgmlms.infra.database
+// AUTO-GENERATED Slick data model
+/** Stand-alone Slick data model for immediate use */
+object Tables extends {
+  val profile = slick.driver.H2Driver
+} with Tables
+
+/** Slick data model trait for extension, choice of backend or usage in the cake pattern. (Make sure to initialize this late.) */
+trait Tables {
+  val profile: slick.driver.JdbcProfile
+  import profile.api._
+  import slick.model.ForeignKeyAction
+  // NOTE: GetResult mappers for plain SQL are only generated for tables where Slick knows how to map the types of all columns.
+  import slick.jdbc.{GetResult => GR}
+
+  /** DDL for all tables. Call .create to execute. */
+  lazy val schema: profile.SchemaDescription = Person.schema ++ SchemaVersion.schema
+  @deprecated("Use .schema instead of .ddl", "3.0")
+  def ddl = schema
+
+  /** Entity class storing rows of table Person
+   *  @param id Database column ID SqlType(INTEGER)
+   *  @param name Database column NAME SqlType(VARCHAR), Length(100,true) */
+  case class PersonRow(id: Int, name: String)
+  /** GetResult implicit for fetching PersonRow objects using plain SQL queries */
+  implicit def GetResultPersonRow(implicit e0: GR[Int], e1: GR[String]): GR[PersonRow] = GR{
+    prs => import prs._
+    PersonRow.tupled((<<[Int], <<[String]))
+  }
+  /** Table description of table PERSON. Objects of this class serve as prototypes for rows in queries. */
+  class Person(_tableTag: Tag) extends Table[PersonRow](_tableTag, "PERSON") {
+    def * = (id, name) <> (PersonRow.tupled, PersonRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = (Rep.Some(id), Rep.Some(name)).shaped.<>({r=>import r._; _1.map(_=> PersonRow.tupled((_1.get, _2.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column ID SqlType(INTEGER) */
+    val id: Rep[Int] = column[Int]("ID")
+    /** Database column NAME SqlType(VARCHAR), Length(100,true) */
+    val name: Rep[String] = column[String]("NAME", O.Length(100,varying=true))
+  }
+  /** Collection-like TableQuery object for table Person */
+  lazy val Person = new TableQuery(tag => new Person(tag))
+
+  /** Entity class storing rows of table SchemaVersion
+   *  @param installedRank Database column installed_rank SqlType(INTEGER), PrimaryKey
+   *  @param version Database column version SqlType(VARCHAR), Length(50,true)
+   *  @param description Database column description SqlType(VARCHAR), Length(200,true)
+   *  @param `type` Database column type SqlType(VARCHAR), Length(20,true)
+   *  @param script Database column script SqlType(VARCHAR), Length(1000,true)
+   *  @param checksum Database column checksum SqlType(INTEGER)
+   *  @param installedBy Database column installed_by SqlType(VARCHAR), Length(100,true)
+   *  @param installedOn Database column installed_on SqlType(TIMESTAMP)
+   *  @param executionTime Database column execution_time SqlType(INTEGER)
+   *  @param success Database column success SqlType(BOOLEAN) */
+  case class SchemaVersionRow(installedRank: Int, version: Option[String], description: String, `type`: String, script: String, checksum: Option[Int], installedBy: String, installedOn: java.sql.Timestamp, executionTime: Int, success: Boolean)
+  /** GetResult implicit for fetching SchemaVersionRow objects using plain SQL queries */
+  implicit def GetResultSchemaVersionRow(implicit e0: GR[Int], e1: GR[Option[String]], e2: GR[String], e3: GR[Option[Int]], e4: GR[java.sql.Timestamp], e5: GR[Boolean]): GR[SchemaVersionRow] = GR{
+    prs => import prs._
+    SchemaVersionRow.tupled((<<[Int], <<?[String], <<[String], <<[String], <<[String], <<?[Int], <<[String], <<[java.sql.Timestamp], <<[Int], <<[Boolean]))
+  }
+  /** Table description of table schema_version. Objects of this class serve as prototypes for rows in queries.
+   *  NOTE: The following names collided with Scala keywords and were escaped: type */
+  class SchemaVersion(_tableTag: Tag) extends Table[SchemaVersionRow](_tableTag, "schema_version") {
+    def * = (installedRank, version, description, `type`, script, checksum, installedBy, installedOn, executionTime, success) <> (SchemaVersionRow.tupled, SchemaVersionRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = (Rep.Some(installedRank), version, Rep.Some(description), Rep.Some(`type`), Rep.Some(script), checksum, Rep.Some(installedBy), Rep.Some(installedOn), Rep.Some(executionTime), Rep.Some(success)).shaped.<>({r=>import r._; _1.map(_=> SchemaVersionRow.tupled((_1.get, _2, _3.get, _4.get, _5.get, _6, _7.get, _8.get, _9.get, _10.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column installed_rank SqlType(INTEGER), PrimaryKey */
+    val installedRank: Rep[Int] = column[Int]("installed_rank", O.PrimaryKey)
+    /** Database column version SqlType(VARCHAR), Length(50,true) */
+    val version: Rep[Option[String]] = column[Option[String]]("version", O.Length(50,varying=true))
+    /** Database column description SqlType(VARCHAR), Length(200,true) */
+    val description: Rep[String] = column[String]("description", O.Length(200,varying=true))
+    /** Database column type SqlType(VARCHAR), Length(20,true)
+     *  NOTE: The name was escaped because it collided with a Scala keyword. */
+    val `type`: Rep[String] = column[String]("type", O.Length(20,varying=true))
+    /** Database column script SqlType(VARCHAR), Length(1000,true) */
+    val script: Rep[String] = column[String]("script", O.Length(1000,varying=true))
+    /** Database column checksum SqlType(INTEGER) */
+    val checksum: Rep[Option[Int]] = column[Option[Int]]("checksum")
+    /** Database column installed_by SqlType(VARCHAR), Length(100,true) */
+    val installedBy: Rep[String] = column[String]("installed_by", O.Length(100,varying=true))
+    /** Database column installed_on SqlType(TIMESTAMP) */
+    val installedOn: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("installed_on")
+    /** Database column execution_time SqlType(INTEGER) */
+    val executionTime: Rep[Int] = column[Int]("execution_time")
+    /** Database column success SqlType(BOOLEAN) */
+    val success: Rep[Boolean] = column[Boolean]("success")
+
+    /** Index over (success) (database name schema_version_s_idx) */
+    val index1 = index("schema_version_s_idx", success)
+  }
+  /** Collection-like TableQuery object for table SchemaVersion */
+  lazy val SchemaVersion = new TableQuery(tag => new SchemaVersion(tag))
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.config.ConfigFactory
+
 name := """cgm-lms"""
 
 version := "1.0-SNAPSHOT"
@@ -14,7 +16,10 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
+  "com.typesafe.slick" %% "slick" % "3.1.1",
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.1.1",
+  "com.typesafe.slick" %% "slick-codegen" % "3.1.1"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
@@ -29,3 +34,30 @@ flywayUrl := "jdbc:h2:file:./target/db/example"
 flywayUser := "sa"
 
 flywayPassword := ""
+
+////////////////////////
+// Slick code generator
+////////////////////////
+slickCodeGen <<= slickCodeGenTask // register sbt command
+//(compile in Compile) <<= (compile in Compile) dependsOn (slickCodeGenTask) // register automatic code generation on compile
+lazy val config = ConfigFactory.parseFile(new File("./conf/application.conf"))
+lazy val slickCodeGen = taskKey[Seq[File]]("slick-codegen")
+lazy val slickCodeGenTask = (sourceManaged, dependencyClasspath in Compile, runner in Compile, streams) map { (dir, cp, r, s) =>
+  val slickDriver = config.getString("slick.dbs.default.driver").init
+  val jdbcDriver = config.getString("slick.dbs.default.db.driver")
+  val url = config.getString("slick.dbs.default.db.url")
+  val outputDir = "app/"
+  val pkg = "sc.ript.cgmlms.infra.database"
+  val username = config.getString("slick.dbs.default.db.user")
+  val password = config.getString("slick.dbs.default.db.password")
+  toError(
+    r.run(
+      "slick.codegen.SourceCodeGenerator",
+      cp.files,
+      Array(slickDriver, jdbcDriver, url, outputDir, pkg, username, password),
+      s.log
+    )
+  )
+  val fname = outputDir + "/Tables.scala"
+  Seq(file(fname))
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,3 +353,17 @@ db {
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
   #default.logSql=true
 }
+
+slick {
+  dbs {
+    default {
+      driver = "slick.driver.H2Driver$"
+      db {
+        driver = "org.h2.Driver"
+        url = "jdbc:h2:file:./target/db/example"
+        user = sa
+        password = ""
+      }
+    }
+  }
+}

--- a/test/SlickCodegenSpec.scala
+++ b/test/SlickCodegenSpec.scala
@@ -1,0 +1,19 @@
+import org.scalatest.{FlatSpec, Matchers}
+import sc.ript.cgmlms.infra.database.Tables._
+import slick.driver.H2Driver.api._
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class SlickCodegenSpec extends FlatSpec with Matchers {
+
+  "SlickCodegen" should "use slick with flyway migration" in {
+    val db = Database.forConfig("slick.dbs.default.db")
+    val resultFuture = db.run(Person.filter(_.id < 3).sortBy(_.id).result).map(_.map(row => (row.id, row.name)))
+    val result = Await.result(resultFuture, Duration.Inf)
+
+    result should be(Seq((1, "John"), (2, "Paul")))
+  }
+
+}


### PR DESCRIPTION
usage

```
> sbt slickCodeGen
[info] Loading project definition from /Users/katou/git/cgm-lms/project
[info] Set current project to cgm-lms (in build file:/Users/katou/git/cgm-lms/)
[warn] *:javaOptions will be ignored, *:fork is set to false
[info] Running slick.codegen.SourceCodeGenerator slick.driver.H2Driver org.h2.Driver jdbc:h2:file:./target/db/example app/ sc.ript.cgmlms.infra.database sa 
16:39:39.278 [run-main-0] DEBUG slick.backend.DatabaseComponent.action - #1: SynchronousDatabaseAction.Pin
16:39:39.292 [AsyncExecutor.default-1] DEBUG slick.backend.DatabaseComponent.action - #2: StreamingResultAction []
16:39:39.553 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #3: StreamingResultAction []
16:39:39.566 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #4: success Vector(MColumn(MQName(EXAMPLE.PUBLIC.PERSON),ID,4,INTEGER,Some(10),Some(0),10,Some(false),Some(),None,10,1,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.PERSON),NAME,12,VARCHAR,Some(100),Some(0),10,Some(false),Some(),None,100,2,Some(false),None,None,Some(false)))
16:39:39.572 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #5: StreamingResultAction []
16:39:39.581 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #6: success Vector()
16:39:39.587 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #7: StreamingResultAction []
16:39:39.604 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #8: success ArrayBuffer()
16:39:39.609 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #9: [fused] asTry
16:39:39.613 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #10: success ArrayBuffer()
16:39:39.614 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #11: success slick.jdbc.JdbcModelBuilder$TableBuilder@56855294
16:39:39.615 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #12: StreamingResultAction []
16:39:39.624 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #13: success Vector(MColumn(MQName(EXAMPLE.PUBLIC.schema_version),installed_rank,4,INTEGER,Some(10),Some(0),10,Some(false),Some(),None,10,1,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),version,12,VARCHAR,Some(50),Some(0),10,Some(true),Some(),None,50,2,Some(true),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),description,12,VARCHAR,Some(200),Some(0),10,Some(false),Some(),None,200,3,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),type,12,VARCHAR,Some(20),Some(0),10,Some(false),Some(),None,20,4,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),script,12,VARCHAR,Some(1000),Some(0),10,Some(false),Some(),None,1000,5,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),checksum,4,INTEGER,Some(10),Some(0),10,Some(true),Some(),None,10,6,Some(true),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),installed_by,12,VARCHAR,Some(100),Some(0),10,Some(false),Some(),None,100,7,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),installed_on,93,TIMESTAMP,Some(23),Some(10),10,Some(false),Some(),Some(CURRENT_TIMESTAMP()),23,8,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),execution_time,4,INTEGER,Some(10),Some(0),10,Some(false),Some(),None,10,9,Some(false),None,None,Some(false)), MColumn(MQName(EXAMPLE.PUBLIC.schema_version),success,16,BOOLEAN,Some(1),Some(0),10,Some(false),Some(),None,1,10,Some(false),None,None,Some(false)))
16:39:39.628 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #14: StreamingResultAction []
16:39:39.636 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #15: success Vector(MPrimaryKey(MQName(EXAMPLE.PUBLIC.schema_version),installed_rank,1,Some(schema_version_pk)))
16:39:39.637 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #16: StreamingResultAction []
16:39:39.639 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #17: success ArrayBuffer()
16:39:39.640 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #18: [fused] asTry
16:39:39.650 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #19: success ArrayBuffer(Vector(MIndexInfo(MQName(EXAMPLE.PUBLIC.schema_version),false,Some(EXAMPLE),Some(PRIMARY_KEY_6),3,1,Some(installed_rank),Some(true),0,0,Some())), Vector(MIndexInfo(MQName(EXAMPLE.PUBLIC.schema_version),true,Some(EXAMPLE),Some(schema_version_s_idx),3,1,Some(success),Some(true),0,0,Some())))
16:39:39.651 [ForkJoinPool-1-worker-5] DEBUG slick.backend.DatabaseComponent.action - #20: success slick.jdbc.JdbcModelBuilder$TableBuilder@7dad9982
16:39:39.660 [ForkJoinPool-1-worker-1] DEBUG slick.backend.DatabaseComponent.action - #21: success (List(slick.jdbc.JdbcModelBuilder$TableBuilder@56855294, slick.jdbc.JdbcModelBuilder$TableBuilder@7dad9982),Map(MQName(EXAMPLE.PUBLIC.PERSON) -> slick.jdbc.JdbcModelBuilder$TableBuilder@56855294, MQName(EXAMPLE.PUBLIC.schema_version) -> slick.jdbc.JdbcModelBuilder$TableBuilder@7dad9982),slick.jdbc.JdbcModelBuilder$Builders@21e81021)
16:39:39.691 [ForkJoinPool-1-worker-1] DEBUG slick.driver.H2Driver$ModelBuilder - Ignoring default value CURRENT_TIMESTAMP() for column EXAMPLE.schema_version.installed_on of type java.sql.Timestamp, meta data: MColumn(MQName(EXAMPLE.PUBLIC.schema_version),installed_on,93,TIMESTAMP,Some(23),Some(10),10,Some(false),Some(),Some(CURRENT_TIMESTAMP()),23,8,Some(false),None,None,Some(false))
16:39:39.700 [ForkJoinPool-1-worker-1] DEBUG slick.backend.DatabaseComponent.action - #22: success Model(List(Table(QualifiedName(PERSON,None,Some(EXAMPLE)),Vector(Column(ID,QualifiedName(PERSON,None,Some(EXAMPLE)),Int,false,Set(SqlType(INTEGER))), Column(NAME,QualifiedName(PERSON,None,Some(EXAMPLE)),String,false,Set(SqlType(VARCHAR), Length(100,true)))),None,ArrayBuffer(),ArrayBuffer(),Set()), Table(QualifiedName(schema_version,None,Some(EXAMPLE)),Vector(Column(installed_rank,QualifiedName(schema_version,None,Some(EXAMPLE)),Int,false,Set(SqlType(INTEGER), PrimaryKey)), Column(version,QualifiedName(schema_version,None,Some(EXAMPLE)),String,true,Set(SqlType(VARCHAR), Length(50,true))), Column(description,QualifiedName(schema_version,None,Some(EXAMPLE)),String,false,Set(SqlType(VARCHAR), Length(200,true))), Column(type,QualifiedName(schema_version,None,Some(EXAMPLE)),String,false,Set(SqlType(VARCHAR), Length(20,true))), Column(script,QualifiedName(schema_version,None,Some(EXAMPLE)),String,false,Set(SqlType(VARCHAR), Length(1000,true))), Column(checksum,QualifiedName(schema_version,None,Some(EXAMPLE)),Int,true,Set(SqlType(INTEGER))), Column(installed_by,QualifiedName(schema_version,None,Some(EXAMPLE)),String,false,Set(SqlType(VARCHAR), Length(100,true))), Column(installed_on,QualifiedName(schema_version,None,Some(EXAMPLE)),java.sql.Timestamp,false,Set(SqlType(TIMESTAMP))), Column(execution_time,QualifiedName(schema_version,None,Some(EXAMPLE)),Int,false,Set(SqlType(INTEGER))), Column(success,QualifiedName(schema_version,None,Some(EXAMPLE)),Boolean,false,Set(SqlType(BOOLEAN)))),None,ArrayBuffer(),ArrayBuffer(Index(Some(schema_version_s_idx),QualifiedName(schema_version,None,Some(EXAMPLE)),Vector(Column(success,QualifiedName(schema_version,None,Some(EXAMPLE)),Boolean,false,Set(SqlType(BOOLEAN)))),false,Set())),Set())),Set())
16:39:39.701 [ForkJoinPool-1-worker-1] DEBUG slick.backend.DatabaseComponent.action - #23: SynchronousDatabaseAction.Unpin
[success] Total time: 1 s, completed 2016/08/11 16:39:39
```
